### PR TITLE
Bump compojure-api version "0.16.4" -> "0.16.5"

### DIFF
--- a/src/leiningen/new/compojure_api/project.clj
+++ b/src/leiningen/new/compojure_api/project.clj
@@ -1,7 +1,7 @@
 (defproject {{name}} "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [metosin/compojure-api "0.16.4"]
+                 [metosin/compojure-api "0.16.5"]
                  [metosin/ring-http-response "0.5.2"]
                  [metosin/ring-swagger-ui "2.0.17"]]
   :ring {:handler {{name}}.handler/app}


### PR DESCRIPTION
Version bump to the latest compojure-api 
